### PR TITLE
fix error when script tag is located at position 0

### DIFF
--- a/lib/structured_data_util.php
+++ b/lib/structured_data_util.php
@@ -382,7 +382,7 @@ class structured_data_util
         $jsonLd = null;
         $startScriptTagPos = strpos($html, '<script type="application/ld+json">');
 
-        if ($startScriptTagPos) {
+        if ($startScriptTagPos !== false) {
             /**
              * Remove anything before '<script type="application/ld+json">'
              * from the HTML


### PR DESCRIPTION
When $startScriptTagPos is 0 it will evaluate to false, even if the substring exists.
Pls see Warning and code examples: https://www.php.net/manual/en/function.strpos.php